### PR TITLE
Added 'starter' and 'component shadowing' to the translation glossary #7

### DIFF
--- a/TRANSLATION.md
+++ b/TRANSLATION.md
@@ -145,3 +145,5 @@ Aquí hay algunas sugerencias para la traducción de términos de uso común en 
 | workspace              | _workspace_                           |
 | monorepo               | _monorepo_                            |
 | fork                   | _fork_                                |
+| starter                | _starter_                             |
+| component shadowing    | _component shadowing_                 |


### PR DESCRIPTION
These terms are used on my docs translation PR: #79 
Related issue: #7 