### PR TITLE
Add "hardcoded" to the style guide common translation list

### DIFF
--- a/TRANSLATION.md
+++ b/TRANSLATION.md
@@ -121,6 +121,7 @@ Aquí hay algunas sugerencias para la traducción de términos de uso común en 
 | DOM                    | DOM                                   |
 | framework              | _framework_                           |
 | function component     | componente de función                 |
+| hardcoded              | hardcodeado                           |
 | hook                   | _hook_                                |
 | key                    | _key_                                 |
 | lazy initialization    | inicialización diferida               |


### PR DESCRIPTION
Hello! While translating `docs/tutorial/authentication-tutorial.md` (#88), I encountered the word "hardcoded". The version in #56 translated it to "codificado", which seems very wrong to me as it loses its original meaning.

I wanted to open this PR for discussion: what should be the correct term?

In my opinion, it's "hardcodeado". Even though [Wikipedia][1] uses "_hard-coded_", on my work everyone uses my proposed version. In our developer language, this word has become an anglicism, like "fútbol".

I think it makes sense to use "hardcodeado", but let's also see how other people feel, especially those from South America which may disagree with me on this.

Thanks for your time!

[1]: https://es.wikipedia.org/wiki/Hard_code