### PR TITLE
Translate css-modules.md

### DIFF
--- a/docs/docs/css-modules.md
+++ b/docs/docs/css-modules.md
@@ -1,22 +1,22 @@
 ---
-title: Component-Scoped Styles with CSS Modules
+title: Estilos en Ámbito por Componentes con Módulos CSS
 ---
 
-Component-scoped CSS allows you to write traditional, portable CSS with minimal side-effects: gone are the worries of selector name collisions or affecting other components' styles.
+CSS en ámbito por componentes te permite escribir CSS tradicional y portátil con efectos secundarios mínimos: no tendrás que preocuparte por conflictos de nombres de selectores o por afectar los estilos de otros componentes.
 
-Gatsby works out of the box with [CSS Modules](https://github.com/css-modules/css-modules), a popular solution for writing component-scoped CSS. Here is an [example site that uses CSS Modules](https://github.com/gatsbyjs/gatsby/tree/master/examples/using-css-modules).
+Gatsby trabaja de manera creativa con los [módulos CSS](https://github.com/css-modules/css-modules), una solución popular para escribir CSS en ámbito por componentes. Aquí tenemos un [ejemplo de un sitio que usa módulos CSS](https://github.com/gatsbyjs/gatsby/tree/master/examples/using-css-modules).
 
-## What is a CSS Module?
+## ¿Qué es un módulo CSS?
 
-Quoting from [the CSS Module homepage](https://github.com/css-modules/css-modules):
+Citando a [la página de inicio de Módulos CSS](https://github.com/css-modules/css-modules):
 
-> A **CSS Module** is a CSS file in which all class names and animation names are scoped locally by default.
+> Un **módulo CSS** es un archivo CSS, en el cual, todos los nombres de clases y animaciones están scoped localmente, por defecto.
 
-CSS Modules let you write styles in CSS files but consume them as JavaScript objects for additional processing and safety. CSS Modules are very popular because they automatically make class and animation names unique so you don't have to worry about selector name collisions.
+Los módulos CSS te permiten escribir estilos en archivos CSS, utilizándolos como objetos JavaScript para procesamiento y seguridad adicionales. Los módulos CSS son muy populares porque, automáticamente, hacen que los nombres de clases y animaciones sean únicos para que no haya que preocuparse por conflictos de nombres de selectores.
 
-### CSS Module example
+### Ejemplo de un módulo CSS
 
-The CSS in a CSS module is no different than normal CSS, but the extension of the file is different to mark that the file will be processed.
+El contenido de un módulo CSS no es diferente al CSS normal, pero la extensión del archivo es diferente para marcar que el archivo será procesado.
 
 ```css:title=src/components/container.module.css
 .container {
@@ -36,13 +36,13 @@ export default ({ children }) => (
 )
 ```
 
-In this example, a CSS module is imported and declared as a JavaScript object called `containerStyles`. Then, a CSS class from that object is referenced in the JSX `className` attribute with `containerStyles.container`, which renders into HTML with dynamic CSS class names like `container-module--container--3MbgH`.
+En este ejemplo, se importa un módulo CSS y se declara como un objeto JavaScript llamado `containerStyles`. Luego, una clase CSS de ese objeto se referencia en el atributo `className` de JSX mediante `containerStyles.container`, el cual se renderiza a HTML con nombres de clases CSS dinámicos, como `container-module--container--3MbgH`.
 
-### Enabling user stylesheets with a stable class name
+### Habilitar hojas de estilo de usuario con un nombre de clase estable
 
-Adding a persistent CSS `className` to your JSX markup along with your CSS Modules code can make it easier for users to take advantage of [User Stylesheets](https://www.viget.com/articles/inline-styles-user-style-sheets-and-accessibility/) for accessibility.
+Agregar un `className` de CSS persistente a tu marcado JSX junto con el código de tus módulos CSS puede facilitarle a los usuarios tomar ventaja de las [Hojas de estilo de usuario](https://www.viget.com/articles/inline-styles-user-style-sheets-and-accessibility/) para accesibilidad.
 
-Here's an example where the class name `container` is added to the DOM along with the module's dynamically-created class names:
+Aquí tenemos un ejemplo donde el nombre de clase `container` se agrega al DOM junto con los nombres de clases del módulo, creados dinámicamente:
 
 ```jsx:title=src/components/container.js
 import React from "react"
@@ -55,13 +55,12 @@ export default ({ children }) => (
 )
 ```
 
-A site user could then write their own CSS styles matching HTML elements with a class name of `.container`, and it wouldn't be affected if the CSS module name or path changed.
+Un usuario del sitio podría escribir, más tarde, sus propios estilos CSS que coincidan con los elementos HTML con un nombre de clase `.container`, y no se verían afectados si llegara a cambiar el nombre o la ruta del módulo CSS.
 
-## When to use CSS Modules
+## ¿Cuándo usar módulos CSS?
 
-CSS Modules are highly recommended for those new to building with Gatsby (and React in general) as they allow you to write regular, portable CSS files while gaining
-performance benefits like only bundling referenced code.
+Los módulos CSS son muy recomendables para quienes están iniciando en crear con Gatsby (y React en general) ya que les permite escribir archivos CSS portátiles y regulares mientras obtienen beneficios de rendimiento como solo agrupar código referenciado.
 
-## How to build a page using CSS Modules
+## ¿Cómo construr una página usando Módulos CSS?
 
-Visit the [CSS Modules section of the tutorial](/tutorial/part-two/#css-modules) for a guided tour of building a page with CSS Modules.
+Visita la [sección Módulos CSS del tutorial](/tutorial/part-two/#css-modules) para un recorrido guiado sobre cómo construir una página con Módulos CSS.


### PR DESCRIPTION
Translated the css-modules.md documentation file. One small observation, though. I am not 100% sure about how accurate the translation of "Component-scoped CSS" is (I translated it to "CSS en ámbitos por componentes").