### PR TITLE
Translate use static query

### DIFF
--- a/docs/docs/use-static-query.md
+++ b/docs/docs/use-static-query.md
@@ -6,7 +6,7 @@ Gatsby v2.1.0 introdujo `useStaticQuery`, una nueva característica de Gatsby qu
 
 Al igual que el componente [StaticQuery](/docs/static-query/), permite que tus componentes de React puedan recibir información vía una consulta de GraphQL que será parseada, evaluada e injectada dentro del componente. Sin embargo, ¡`useStaticQuery` es un hook más que un componente que toma propiedades de rendereo!
 
-En esta guía, veremos un ejemplo de uso de `useStaticQuery`. Si todavía no estas familiarizado con las consultas estáticas en Gatsby, quizás deberíasa darle un vistazo a [la diferencia entre una consulta estática y una consulta de página](/docs/static-query/#how-staticquery-differs-from-page-query).
+En esta guía, veremos un ejemplo de uso de `useStaticQuery`. Si todavía no estas familiarizado con las consultas estáticas en Gatsby, quizás deberías darle un vistazo a [la diferencia entre una consulta estática y una consulta de página](/docs/static-query/#how-staticquery-differs-from-page-query).
 
 ## Cómo usar useStaticQuery en componentes
 
@@ -14,7 +14,7 @@ En esta guía, veremos un ejemplo de uso de `useStaticQuery`. Si todavía no est
 >
 > 📦 `npm install react@^16.8.0 react-dom@^16.8.0`
 
-`useStaticQuery` es un React Hook. Todas las [Reglas de Hooks](https://reactjs.org/docs/hooks-rules.html) aplican.
+`useStaticQuery` es un React Hook. Todas las [Reglas de Hooks](https://es.reactjs.org/docs/hooks-rules.html) aplican.
 
 Esto toma tus consultas de GraphQL y retorna la información solicitada. ¡Así de simple!
 

--- a/docs/docs/use-static-query.md
+++ b/docs/docs/use-static-query.md
@@ -1,26 +1,26 @@
 ---
-title: Consultando información en componentes utilizando useStaticQuery Hook
+Título: Consultando información en componentes utilizando useStaticQuery Hook
 ---
 
 Gatsby v2.1.0 introdujo `useStaticQuery`, una nueva característica de Gatsby que provee la habilidad de usar [React Hook](https://reactjs.org/docs/hooks-intro.html) para hacer consultas con GraphQL en _build time_.
 
-Al igual que el componente [StaticQuery](/docs/static-query/), permite que tu componente de React pueda recibir información via una consulta de GraphQL que es parseada, evaluada e injectada dentro del componente. ¡Sin embargo, `useStaticQuery` es un hook más que un componente que toma propiedades de rendereo!
+Al igual que el componente [StaticQuery](/docs/static-query/), permite que tus componentes de React puedan recibir información vía una consulta de GraphQL que será parseada, evaluada e injectada dentro del componente. Sin embargo, ¡`useStaticQuery` es un hook más que un componente que toma propiedades de rendereo!
 
-En esta guía, vas a transitar por un ejemplo utilizando `useStaticQuery`. Si todavía no estas familiarizado con las consultas estáticas en Gatsby, quizás deberíasa darle un vistazo a [la diferencia entre una consulta estática y una consulta de página](/docs/static-query/#how-staticquery-differs-from-page-query).
+En esta guía, veremos un ejemplo de uso de `useStaticQuery`. Si todavía no estas familiarizado con las consultas estáticas en Gatsby, quizás deberíasa darle un vistazo a [la diferencia entre una consulta estática y una consulta de página](/docs/static-query/#how-staticquery-differs-from-page-query).
 
 ## Cómo usar useStaticQuery en componentes
 
-> 💡 Vas a necesitar React y ReactDOM 16.8.0 or mayor para usar `useStaticQuery`.
+> 💡 Vas a necesitar React y ReactDOM 16.8.0 o mayor para usar `useStaticQuery`.
 >
 > 📦 `npm install react@^16.8.0 react-dom@^16.8.0`
 
 `useStaticQuery` es un React Hook. Todas las [Reglas de Hooks](https://reactjs.org/docs/hooks-rules.html) aplican.
 
-Esto toma tus consultas de GraphQL y retorna la información solicitada. ¡Simplemente así!
+Esto toma tus consultas de GraphQL y retorna la información solicitada. ¡Así de simple!
 
 ### Ejemplo básico
 
-Vamos a crear componente `Header` que va a consultar por el título del sitio desde `gatsby-config.js`:
+Creamos un componente `Header` que consulte por el título del sitio desde `gatsby-config.js`:
 
 ```jsx:title=src/components/header.js
 import React from "react"
@@ -45,11 +45,11 @@ export default () => {
 }
 ```
 
-### Componiendo un `useStaticQuery` hooks personalizado
+### Componiendo hooks de `useStaticQuery` personalizados
 
-Uno de las características más convincentes de hooks is the ability to compose and re-use these blocks of functionality. `useStaticQuery` is a hook. Therefore, using `useStaticQuery` allows us to compose and re-use blocks of reusable functionality. Perfect!
+Uno de las características más convincentes de hooks es la habilidad de componer y reutilizar estos bloques de funcionalidad. `useStaticQuery` es un hook. Por lo tanto, usar `useStaticQuery` nos permite componer y reutilizar bloques de funcionalidades reutilizable. ¡Perfecto!
 
-A classic example is to create a `useSiteMetadata` hook which will provide the `siteMetadata` to be re-used in any component. It looks something like:
+Un ejemplo clásico es crear un `useSiteMetadata` hook el cuál permitira proveer al `siteMetadata` ser reutilizado en cualquier componente. Esto se ve algo así:
 
 ```jsx:title=src/hooks/use-site-metadata.js
 import { useStaticQuery, graphql } from "gatsby"
@@ -78,7 +78,7 @@ export const useSiteMetadata = () => {
 }
 ```
 
-Then just import your newly created hook, like so:
+Entonces solamente importamos el nuevo hook creado, así:
 
 ```jsx:title=src/pages/index.js
 import React from "react"
@@ -90,7 +90,7 @@ export default () => {
 }
 ```
 
-## Known Limitations
+## Limitaciones a considerar
 
-- `useStaticQuery` does not accept variables (hence the name "static"), but can be used in _any_ component, including pages
-- Because of how queries currently work in Gatsby, we support only a single instance of `useStaticQuery` in a file
+- `useStaticQuery` no acepta variables (por eso el nombre "static"), pero puede ser usado en _cualquier_ componente, incluido páginas
+- Debido a como funcionan las consultas actualmente en Gatsby, nosotros solamente damos soporte a una sola instancia de `useStaticQuery` en un archivo

--- a/docs/docs/use-static-query.md
+++ b/docs/docs/use-static-query.md
@@ -92,5 +92,5 @@ export default () => {
 
 ## Limitaciones a considerar
 
-- `useStaticQuery` no acepta variables (por eso el nombre "static"), pero puede ser usado en _cualquier_ componente, incluido páginas
-- Debido a como funcionan las consultas actualmente en Gatsby, nosotros solamente damos soporte a una sola instancia de `useStaticQuery` en un archivo
+- `useStaticQuery` no acepta variables (por eso el nombre "static"), pero puede ser usado en _cualquier_ componente, incluido páginas.
+- Debido a como funcionan las consultas actualmente en Gatsby, nosotros solamente damos soporte a una sola instancia de `useStaticQuery` en un archivo.

--- a/docs/docs/use-static-query.md
+++ b/docs/docs/use-static-query.md
@@ -2,7 +2,7 @@
 Título: Consultando información en componentes utilizando useStaticQuery Hook
 ---
 
-Gatsby v2.1.0 introdujo `useStaticQuery`, una nueva característica de Gatsby que provee la habilidad de usar [React Hook](https://reactjs.org/docs/hooks-intro.html) para hacer consultas con GraphQL en _build time_.
+Gatsby v2.1.0 introdujo `useStaticQuery`, una nueva característica de Gatsby que provee la habilidad de usar [React Hook](https://es.reactjs.org/docs/hooks-rules.html) para hacer consultas con GraphQL en _build time_.
 
 Al igual que el componente [StaticQuery](/docs/static-query/), permite que tus componentes de React puedan recibir información vía una consulta de GraphQL que será parseada, evaluada e injectada dentro del componente. Sin embargo, ¡`useStaticQuery` es un hook más que un componente que toma propiedades de rendereo!
 

--- a/docs/docs/use-static-query.md
+++ b/docs/docs/use-static-query.md
@@ -1,26 +1,26 @@
 ---
-title: Querying Data in Components with the useStaticQuery Hook
+title: Consultando información en componentes utilizando useStaticQuery Hook
 ---
 
-Gatsby v2.1.0 introduces `useStaticQuery`, a new Gatsby feature that provides the ability to use a [React Hook](https://reactjs.org/docs/hooks-intro.html) to query with GraphQL at _build time_.
+Gatsby v2.1.0 introdujo `useStaticQuery`, una nueva característica de Gatsby que provee la habilidad de usar [React Hook](https://reactjs.org/docs/hooks-intro.html) para hacer consultas con GraphQL en _build time_.
 
-Just like the [StaticQuery](/docs/static-query/) component, it allows your React components to retrieve data via a GraphQL query that will be parsed, evaluated, and injected into the component. However, `useStaticQuery` is a hook rather than a component that takes a render prop!
+Al igual que el componente [StaticQuery](/docs/static-query/), permite que tu componente de React pueda recibir información via una consulta de GraphQL que es parseada, evaluada e injectada dentro del componente. ¡Sin embargo, `useStaticQuery` es un hook más que un componente que toma propiedades de rendereo!
 
-In this guide, you will walk through an example using `useStaticQuery`. If you're not familiar with static queries in Gatsby, you might want to check out [the difference between a static query and a page query](/docs/static-query/#how-staticquery-differs-from-page-query).
+En esta guía, vas a transitar por un ejemplo utilizando `useStaticQuery`. Si todavía no estas familiarizado con las consultas estáticas en Gatsby, quizás deberíasa darle un vistazo a [la diferencia entre una consulta estática y una consulta de página](/docs/static-query/#how-staticquery-differs-from-page-query).
 
-## How to use useStaticQuery in components
+## Cómo usar useStaticQuery en componentes
 
-> 💡 You'll need React and ReactDOM 16.8.0 or later to use `useStaticQuery`.
+> 💡 Vas a necesitar React y ReactDOM 16.8.0 or mayor para usar `useStaticQuery`.
 >
 > 📦 `npm install react@^16.8.0 react-dom@^16.8.0`
 
-`useStaticQuery` is a React Hook. All the [Rules of Hooks](https://reactjs.org/docs/hooks-rules.html) apply.
+`useStaticQuery` es un React Hook. Todas las [Reglas de Hooks](https://reactjs.org/docs/hooks-rules.html) aplican.
 
-It takes your GraphQL query and returns the requested data. That's it!
+Esto toma tus consultas de GraphQL y retorna la información solicitada. ¡Simplemente así!
 
-### Basic example
+### Ejemplo básico
 
-Let's create a `Header` component that queries for the site title from `gatsby-config.js`:
+Vamos a crear componente `Header` que va a consultar por el título del sitio desde `gatsby-config.js`:
 
 ```jsx:title=src/components/header.js
 import React from "react"
@@ -45,9 +45,9 @@ export default () => {
 }
 ```
 
-### Composing custom `useStaticQuery` hooks
+### Componiendo un `useStaticQuery` hooks personalizado
 
-One of the most compelling features of hooks is the ability to compose and re-use these blocks of functionality. `useStaticQuery` is a hook. Therefore, using `useStaticQuery` allows us to compose and re-use blocks of reusable functionality. Perfect!
+Uno de las características más convincentes de hooks is the ability to compose and re-use these blocks of functionality. `useStaticQuery` is a hook. Therefore, using `useStaticQuery` allows us to compose and re-use blocks of reusable functionality. Perfect!
 
 A classic example is to create a `useSiteMetadata` hook which will provide the `siteMetadata` to be re-used in any component. It looks something like:
 

--- a/docs/docs/use-static-query.md
+++ b/docs/docs/use-static-query.md
@@ -86,7 +86,7 @@ import { useSiteMetadata } from "../hooks/use-site-metadata"
 
 export default () => {
   const { title, siteUrl } = useSiteMetadata()
-  return <h1>welcome to {title}</h1>
+  return <h1>Bienvenido a {title}</h1>
 }
 ```
 


### PR DESCRIPTION
Ya está lista la traducción d `use-static-query.md`. Hay algunas cosas que no traduje porque no estaba seguro si debía hacerlo, como: _build time_ y hooks