### PR TITLE
Add node_modules/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,5 @@ ehthumbs_vista.db
 # Generated files
 .idea/
 
+# node_modules in case someone runs yarn on the project
+node_modules/


### PR DESCRIPTION
Hi! Not a translation PR, but a quick fix to maybe save someone from the headache later. 

## Description

This change adds `node_modules/` to `.gitignore`. 

If a user tries to change the repo, but runs `yarn` out of habit, this PR will prevent there from being errors when the user tries to `git add *` and `git commit -m "message"`



